### PR TITLE
Add local-state chat app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+dist
+.env.local

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,14 @@
+import './globals.css';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Public Chat',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="h-screen">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState, useRef, useEffect } from 'react';
+
+type ChatMessage = {
+  id: number;
+  text?: string;
+  file?: {
+    url: string;
+    type: 'image' | 'video';
+  };
+  sender: 'me' | 'other';
+};
+
+export default function Page() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  const sendMessage = () => {
+    if (!input && !file) return;
+    const msg: ChatMessage = {
+      id: Date.now(),
+      sender: 'me',
+    };
+    if (input) msg.text = input;
+    if (file) {
+      const url = URL.createObjectURL(file);
+      const type = file.type.startsWith('image')
+        ? 'image'
+        : file.type.startsWith('video')
+        ? 'video'
+        : null;
+      if (type) msg.file = { url, type };
+    }
+    setMessages(prev => [...prev, msg]);
+    setInput('');
+    setFile(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) setFile(f);
+  };
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="bg-blue-600 text-white p-4 text-center font-semibold">
+        💬 Public Chat
+      </header>
+      <main className="flex-1 overflow-y-auto p-4 space-y-3">
+        {messages.map(m => (
+          <div key={m.id} className={`flex ${m.sender === 'me' ? 'justify-end' : 'justify-start'}`}>
+            <div
+              className={`max-w-xs sm:max-w-md p-3 rounded-lg space-y-2 ${
+                m.sender === 'me'
+                  ? 'bg-blue-500 text-white rounded-br-none'
+                  : 'bg-gray-300 text-gray-900 rounded-bl-none'
+              }`}
+            >
+              {m.text && <p className="whitespace-pre-wrap">{m.text}</p>}
+              {m.file?.type === 'image' && (
+                <img src={m.file.url} alt="uploaded" className="rounded" />
+              )}
+              {m.file?.type === 'video' && (
+                <video src={m.file.url} controls className="rounded max-h-60" />
+              )}
+            </div>
+          </div>
+        ))}
+        <div ref={endRef} />
+      </main>
+      <div className="p-4 bg-white flex items-center gap-2">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*,video/*"
+          onChange={handleFileChange}
+          className="hidden"
+        />
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="p-2 rounded-full hover:bg-gray-200"
+        >
+          📎
+        </button>
+        <input
+          type="text"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Type a message"
+          className="flex-1 rounded-full border px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button
+          onClick={sendMessage}
+          className="p-2 text-blue-600 hover:text-blue-800"
+        >
+          ➤
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "public-chat",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "next build"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js project with Tailwind CSS and TypeScript
- implement responsive chat UI storing messages in React state only
- support text, image, and video messages with previews

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm test` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a12c65945c8320a6fd2f9551970b03