### PR TITLE
Add websocket-based realtime chat

### DIFF
--- a/app/api/socket/route.ts
+++ b/app/api/socket/route.ts
@@ -1,0 +1,28 @@
+export const runtime = 'edge';
+
+const clients = new Set<WebSocket>();
+
+export async function GET(request: Request) {
+  if (request.headers.get('upgrade') !== 'websocket') {
+    return new Response('Expected websocket', { status: 400 });
+  }
+  const { 0: client, 1: server } = Object.values(new WebSocketPair());
+  server.accept();
+  clients.add(server);
+
+  server.addEventListener('message', event => {
+    clients.forEach(ws => {
+      try {
+        ws.send(event.data);
+      } catch (err) {
+        // ignore broken connections
+      }
+    });
+  });
+
+  server.addEventListener('close', () => {
+    clients.delete(server);
+  });
+
+  return new Response(null, { status: 101, webSocket: client });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,24 +18,34 @@ export default function Page() {
   const [file, setFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const clientId = useRef<string>('' + Date.now() + Math.random());
 
   const sendMessage = () => {
-    if (!input && !file) return;
-    const msg: ChatMessage = {
+    if (!wsRef.current || (!input && !file)) return;
+    const payload: any = {
       id: Date.now(),
-      sender: 'me',
+      senderId: clientId.current,
     };
-    if (input) msg.text = input;
+    if (input) payload.text = input;
+    const finalize = () => {
+      wsRef.current?.send(JSON.stringify(payload));
+    };
     if (file) {
-      const url = URL.createObjectURL(file);
-      const type = file.type.startsWith('image')
-        ? 'image'
-        : file.type.startsWith('video')
-        ? 'video'
-        : null;
-      if (type) msg.file = { url, type };
+      const reader = new FileReader();
+      reader.onload = () => {
+        const type = file.type.startsWith('image')
+          ? 'image'
+          : file.type.startsWith('video')
+          ? 'video'
+          : null;
+        if (type) payload.file = { url: reader.result as string, type };
+        finalize();
+      };
+      reader.readAsDataURL(file);
+    } else {
+      finalize();
     }
-    setMessages(prev => [...prev, msg]);
     setInput('');
     setFile(null);
     if (fileInputRef.current) fileInputRef.current.value = '';
@@ -49,6 +59,28 @@ export default function Page() {
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
+
+  useEffect(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const socket = new WebSocket(`${protocol}://${window.location.host}/api/socket`);
+    wsRef.current = socket;
+    socket.onmessage = event => {
+      try {
+        const data = JSON.parse(event.data);
+        const sender = data.senderId === clientId.current ? 'me' : 'other';
+        const msg: ChatMessage = {
+          id: data.id,
+          text: data.text,
+          file: data.file,
+          sender,
+        };
+        setMessages(prev => [...prev, msg]);
+      } catch {}
+    };
+    return () => {
+      socket.close();
+    };
+  }, []);
 
   return (
     <div className="flex flex-col h-full">


### PR DESCRIPTION
## Summary
- add edge runtime websocket endpoint that broadcasts messages to connected clients
- hook chat UI to websocket with client ids and file support

## Testing
- `npm test` *(fails: Failed to install required TypeScript dependencies)*
- `npm install --save-dev @types/react @types/node` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_68a1330cf16c8320a27ec2b3ea3fda25